### PR TITLE
Fix namespace problem with embeds

### DIFF
--- a/src/Discord/Parts/Channel/Message.php
+++ b/src/Discord/Parts/Channel/Message.php
@@ -160,7 +160,7 @@ class Message extends Part
         $embeds = new Collection();
 
         foreach ($this->attributes['embeds'] as $embed) {
-            $embeds->push($this->factory->create(Embed::class, $embed, true));
+            $embeds->push($this->factory->create(Discord\Parts\Embed\Embed::class, $embed, true));
         }
 
         return $embeds;


### PR DESCRIPTION
Embed::class is located in 
Discord\Parts\Embed\Embed
and not in
Discord\Parts\Channel (current namespace at begin of file)
So, updated Embed::class to refer to the right namespace

Fixing issue: https://github.com/teamreflex/DiscordPHP/issues/235#issuecomment-296713167